### PR TITLE
Put 'by' before artist name

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func tokenSet(dg *dgo.Session, r lrt) error {
 				Name:    ftitle,
 				Type:    2,
 				Details: ctrack.Name,
-				State:   ctrack.Artist.Name,
+				State:   "by " + ctrack.Artist.Name,
 			},
 		},
 	)
@@ -187,7 +187,7 @@ func appSet(_ *dgo.Session, r lrt) error {
 	return rgo.SetActivity(
 		rgo.Activity{
 			Details:    ctrack.Name,
-			State:      ctrack.Artist.Name,
+			State:      "by " + ctrack.Artist.Name,
 			LargeImage: flimg,
 			LargeText:  fltext,
 			SmallImage: conf.App.SmallImage,


### PR DESCRIPTION
I think the presence would be better if it were to explicitly list who the artist is.
This more closely mirrors the way Spotify does it.
For instance:
![image](https://user-images.githubusercontent.com/42429413/167283235-01628544-7cfd-446a-86a8-d6ad67ab347d.png)

This PR does:
```diff
- State: ctrack.Artist.Name,
+ State: "by " + ctrack.Artist.Name,
```

----

Maybe this could be configurable? For instance the format shown in that image could be : 
```toml
main_text = "{{name}}"
secondary_text = "by {{artist}}"
```